### PR TITLE
Chore(Front-Proxy): Update External ID handling

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,5 +1,6 @@
 {
-"name": "Heroku Stripe Proxy",
+  "name": "Heroku Stripe Proxy",
+  "stack": "heroku-24",
   "description": "Forward Stripe event webhooks to all review apps in a Heroku pipeline",
   "keywords": [
     "stripe",

--- a/lib/front/webhookHandler.js
+++ b/lib/front/webhookHandler.js
@@ -23,8 +23,8 @@ class WebhookHandler {
 
         return {
           requestType: this.requestType,
-          // Review App Chatroom IDs are joined with { Heroku PR Number } and { sprintf("%03d", chatroom_id) }
-          target: externalId.toString().slice(0, -3),
+          // Review App Chatroom IDs take the format: `${PR_Number}-{6_char_Base58_encoded_random_string}`
+          target: externalId.split("-")[0],
           json: { type: 'success', message: 'Event forwarded' },
         }
     }


### PR DESCRIPTION
Our review app chatroom external IDs now follow the convention:
`${heroku_pr_number}-${external_id}`

Hence the change 